### PR TITLE
API DELETE Endpoints for Dogs and Walkers

### DIFF
--- a/Program.cs
+++ b/Program.cs
@@ -137,7 +137,19 @@ app.MapGet("/api/dog-assign", (int walkerId) =>
     return Results.Ok(dogsInCity);
 });
 
-app.MapDelete("/api/dogs/{id}", (int id) => $"Delete dog with id {id}");
+app.MapDelete("/api/dogs/{id}", (int id) =>
+{
+    var dogToDelete = dogs.FirstOrDefault(d => d.Id == id);
+
+    if (dogToDelete == null)
+    {
+        return Results.NotFound();
+    }
+
+    dogs.Remove(dogToDelete);
+
+    return Results.NoContent();
+});
 
 // Walkers
 app.MapGet("/api/walkers", () =>
@@ -200,7 +212,26 @@ app.MapPut("/api/walkers/{id}", (int id, WalkerDTO newWalkerDTO) =>
     });
 });
 
-app.MapDelete("/api/walkers/{id}", (int id) => $"Delete walker with id {id}");
+app.MapDelete("/api/walkers/{id}", (int id) =>
+{
+    var walkerToDelete = walkers.FirstOrDefault(w => w.Id == id);
+
+    if (walkerToDelete == null)
+    {
+        return Results.NotFound();
+    }
+
+    foreach (var dog in dogs.Where(d => d.WalkerId == id))
+    {
+        dog.WalkerId = null;
+    }
+
+    cityWalkers = cityWalkers.Where(cw => cw.WalkerId != id).ToList();
+
+    walkers.Remove(walkerToDelete);
+
+    return Results.NoContent();
+});
 
 // Cities
 app.MapGet("/api/cities", () =>


### PR DESCRIPTION
# Description

Implemented API for final user stories (8 & 9). We have one for deleting dogs and another for deleting walkers. The latter endpoint also sets the WalkerId for all dogs assigned to that walker to null and removes all links that walker has in the CityWalker join table. Our final step for this app's frontend will be to implement these APIs into the UI.

## Type of change

- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?

- [x] DELETE a dog at the /api/dogs/{id} endpoint. Then, GET the dogs list to make sure it's removed.
- [x] DELETE a walker at /api/walkers/{id} endpoint. Then, you must (a) GET the list of dogs to make sure all WalkerIds for the dogs who were assigned to that walker are set to null and (b) access the citywalkers associated with that walker with api/walkers-by-city in Postman/Swagger.

# Checklist:

- [x] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [x] I have commented my code, particularly in hard-to-understand areas
- [x] My changes generate no new warnings